### PR TITLE
Update dawn to a recent version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(server
   dawn_native
   dawn_wire
   dawn_utils
-  glfw
+  dawn_glfw
   "ev"
 )
 add_executable(client
@@ -50,6 +50,9 @@ target_link_directories(client PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/libev/lib )
 
 target_include_directories(server PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/libev/include )
 target_include_directories(client PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/libev/include )
+
+target_compile_options(server PRIVATE -fno-rtti)
+target_compile_options(client PRIVATE -fno-rtti)
 
 if (${CMAKE_BUILD_TYPE} MATCHES "Debug")
   target_compile_definitions(server PRIVATE DEBUG=1)

--- a/client.cc
+++ b/client.cc
@@ -14,12 +14,12 @@
 
 #include "protocol.hh"
 
-#include "utils/ComboRenderPipelineDescriptor.h"
-#include "utils/WGPUHelpers.h"
-
-#include <dawn/webgpu.h>
+#include <dawn/common/Assert.h>
 #include <dawn/dawn_proc.h>
-#include <dawn_wire/WireClient.h>
+#include <dawn/utils/ComboRenderPipelineDescriptor.h>
+#include <dawn/utils/WGPUHelpers.h>
+#include <dawn/webgpu.h>
+#include <dawn/wire/WireClient.h>
 
 #include <cmath>
 #include <iostream>
@@ -188,7 +188,7 @@ struct Connection {
   }
 
   void initDawnPipeline() {
-    utils::ComboRenderPipelineDescriptor2 desc;
+    utils::ComboRenderPipelineDescriptor desc;
     desc.vertex.module = utils::CreateShaderModule(device, R"(
       let pos : array<vec2<f32>, 3> = array<vec2<f32>, 3>(
           vec2<f32>( 0.0,  0.5),
@@ -208,7 +208,7 @@ struct Connection {
     )");
     desc.cTargets[0].format = wgpu::TextureFormat::BGRA8Unorm;
 
-    pipeline = device.CreateRenderPipeline2(&desc); // global var
+    pipeline = device.CreateRenderPipeline(&desc); // global var
   }
 
   void start(RunLoop* rl, int fd) {
@@ -236,9 +236,9 @@ struct Connection {
       BLUE  = std::abs(cosf(float(fc*10) / 80));
     }
 
-    wgpu::RenderPassColorAttachmentDescriptor colorAttachment;
+    wgpu::RenderPassColorAttachment colorAttachment;
     colorAttachment.view = swapchain.GetCurrentTextureView();
-    colorAttachment.clearColor = {RED, GREEN, BLUE, 0.0f};
+    colorAttachment.clearValue = {RED, GREEN, BLUE, 0.0f};
     colorAttachment.loadOp = wgpu::LoadOp::Clear;
     colorAttachment.storeOp = wgpu::StoreOp::Store;
 

--- a/protocol.hh
+++ b/protocol.hh
@@ -5,9 +5,9 @@
 #include <limits>
 #include <algorithm>
 
-#include <dawn_wire/Wire.h>
-#include <dawn_wire/WireClient.h>
 #include <dawn/webgpu_cpp.h>
+#include <dawn/wire/Wire.h>
+#include <dawn/wire/WireClient.h>
 
 // DEBUG_TRACE_PROTOCOL: define to trace protocol I/O
 // #define DEBUG_TRACE_PROTOCOL
@@ -29,7 +29,7 @@ typedef struct ev_loop RunLoop;
 #define DAWNCMD_MAX             (4096*32)
 #define DAWNCMD_BUFSIZE         (DAWNCMD_MAX + DAWNCMD_MSG_HEADER_SIZE)
 
-struct DawnRemoteProtocol : public dawn_wire::CommandSerializer {
+struct DawnRemoteProtocol : public dawn::wire::CommandSerializer {
   struct FramebufferInfo {
     wgpu::TextureFormat textureFormat;
     wgpu::TextureUsage  textureUsage;

--- a/server.cc
+++ b/server.cc
@@ -14,13 +14,13 @@
 
 #include "protocol.hh"
 
-#include "utils/GLFWUtils.h"
 #include "GLFW/glfw3.h"
 
-#include <dawn/webgpu_cpp.h>
 #include <dawn/dawn_proc.h>
-#include <dawn_wire/WireServer.h>
-#include <dawn_native/DawnNative.h>
+#include <dawn/native/DawnNative.h>
+#include <dawn/webgpu_cpp.h>
+#include <dawn/wire/WireServer.h>
+#include <webgpu/webgpu_glfw.h>
 
 #include <algorithm>
 #include <cmath>
@@ -375,7 +375,6 @@ void createOSWindow() {
     return;
 
   // Setup the correct hints for GLFW for backends.
-  utils::SetupGLFWWindowHintsForBackend(backendType);
   glfwWindowHint(GLFW_COCOA_RETINA_FRAMEBUFFER, GLFW_FALSE);
   window = glfwCreateWindow(
     framebufferInfo.width,
@@ -434,7 +433,8 @@ void createDawnDevice() {
 }
 
 void createDawnSwapChain() {
-  surface = utils::CreateSurfaceForWindow(instance->Get(), window); // global var
+  surface =
+      wgpu::glfw::CreateSurfaceForWindow(instance->Get(), window); // global var
   wgpu::SwapChainDescriptor desc = {
     .format = framebufferInfo.textureFormat,
     .usage  = framebufferInfo.textureUsage,

--- a/setup.sh
+++ b/setup.sh
@@ -14,7 +14,7 @@ fi
 
 cd dawn
 echo "cd $PWD"
-git checkout --detach c74af7037817b2b5324d2097ea0f277044424b19 --
+git checkout chromium/5715 --
 
 cp scripts/standalone.gclient .gclient
 echo gclient sync


### PR DESCRIPTION
This makes the code compile with a recent Dawn version, but I wonder if additional changes are needed since I don't see anything drawn on the window the server process pops up.

Also, when I terminate the client, the server process crashes with a segfault. :)